### PR TITLE
[room-client-js] Added RPC request on stream `unpublish` method

### DIFF
--- a/kurento-room-client-js/src/main/resources/static/js/KurentoRoom.js
+++ b/kurento-room-client-js/src/main/resources/static/js/KurentoRoom.js
@@ -711,8 +711,17 @@ function Stream(kurento, local, room, options) {
 	            })
         	}
         }
-    	
-    	console.log(that.getGlobalID() + ": Stream '" + id + "' unpublished");
+
+        kurento.sendRequest('unpublishVideo', function (error, response) {
+            if (error) {
+                console.error(error);
+            } else {
+                that.room.emitEvent('stream-unpublished', [{
+                  stream: that
+                }]);
+                console.log(that.getGlobalID() + ": Stream '" + id + "' unpublished");
+            }
+        });
     }
     
     this.dispose = function () {


### PR DESCRIPTION
I've added RPC request on stream `unpublish` method. That change enables to *unpublish* stream by ending `MediaStream` and notify server (and other participants) that stream was unpublished. It also keep participant connected to the room.

That change was made to be consistent with Java Android Kurento library.

Please verify.