### PR TITLE
Stop switching the main speaker to the participant that is already the main speaker

### DIFF
--- a/kurento-room-demo/src/main/resources/static/angular/services/Participants.js
+++ b/kurento-room-demo/src/main/resources/static/angular/services/Participants.js
@@ -131,11 +131,13 @@ function Participants() {
     };
 
     function updateMainParticipant(participant) {
-        if (mainParticipant) {
-        	mainParticipant.removeMain();
+        if (!mainParticipant || (mainParticipant != participant)) {
+            if (mainParticipant) {
+                mainParticipant.removeMain();
+            }
+            mainParticipant = participant;
+            mainParticipant.setMain();
         }
-        mainParticipant = participant;
-        mainParticipant.setMain();
     }
 
     this.addLocalParticipant = function (stream) {


### PR DESCRIPTION
Fixed a bug where we would keep switching the main speaker to a participant, even if it was already the main speaker, causing a flickering in the view.