### PR TITLE
updated deprecated function

### DIFF
--- a/kurento-room-client-js/src/main/resources/static/js/KurentoRoom.js
+++ b/kurento-room-client-js/src/main/resources/static/js/KurentoRoom.js
@@ -568,7 +568,11 @@ function Stream(kurento, local, room, options) {
         video.autoplay = true;
         video.controls = false;
         if (wrStream) {
-            video.src = URL.createObjectURL(wrStream);
+            try {
+                   video.srcObject = wrStream;
+                 } catch (error) {
+                        video.src = URL.createObjectURL(wrStream);
+                      }
             $(jq(thumbnailId)).show();
             hideSpinner();
         } else


### PR DESCRIPTION
the function URL.createObjectURL is deprecated and is replaced by  video.srcObject = wrStream;